### PR TITLE
Fix typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     description="Python wrapper for EcoWitt Protocol",
     long_description=README_FILE.read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
-    packages=find_packages(exclude=["test.*", "test", "misc"]),
+    packages=find_packages(exclude=["tests.*", "tests", "misc"]),
     package_data={"aioecowitt": ["py.typed"]},
     python_requires=">=3.9",
     install_requires=["aiohttp>3", "meteocalc>=1.1.0"],


### PR DESCRIPTION
tests directory is called 'tests', not 'test', setup.py ("which is is deprecated and slated for removal") so tries to install a package called "tests" at top level:

````
>>> Verifying ebuild manifests
>>> Emerging (1 of 2) dev-python/meteocalc-1.1.0::HomeAssistantRepository
>>> Installing (1 of 2) dev-python/meteocalc-1.1.0::HomeAssistantRepository
>>> Emerging (2 of 2) dev-python/aioecowitt-2022.8.3::HomeAssistantRepository
>>> Failed to emerge dev-python/aioecowitt-2022.8.3, Log file:
>>>  '/var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/build.log'
>>> Jobs: 1 of 2 complete, 1 failed                 Load avg: 0.53, 0.21, 0.12
 * Package:    dev-python/aioecowitt-2022.8.3
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   hello@home-assistant.io
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_10 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking aioecowitt-2022.8.3.tar.gz to /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work
>>> Source unpacked in /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work
>>> Preparing source in /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3 ...
 * Build system packages:
 *   dev-python/setuptools         : 63.2.0
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3 ...
 * python3_10: running distutils-r1_run_phase distutils-r1_python_compile
python3.10 setup.py build -j 6
/usr/lib/python3.10/site-packages/setuptools/dist.py:530: UserWarning: Normalizing '2022.08.3' to '2022.8.3'
  warnings.warn(tmpl.format(**locals()))
running build
running build_py
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/test_sensor.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/const.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/test_station.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/test_calc.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
copying tests/test_server.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/__main__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/calc.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/__init__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/sensor.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/station.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
copying aioecowitt/server.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt
running egg_info
writing aioecowitt.egg-info/PKG-INFO
writing dependency_links to aioecowitt.egg-info/dependency_links.txt
writing entry points to aioecowitt.egg-info/entry_points.txt
writing requirements to aioecowitt.egg-info/requires.txt
writing top-level names to aioecowitt.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'aioecowitt.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'aioecowitt.egg-info/SOURCES.txt'
warning: build_py: byte-compiling is disabled, skipping.

>>> Source compiled.
>>> Test phase [not enabled]: dev-python/aioecowitt-2022.8.3

>>> Install dev-python/aioecowitt-2022.8.3 into /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image
 * python3_10: running distutils-r1_run_phase distutils-r1_python_install
python3.10 setup.py install --skip-build --root=/var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10
/usr/lib/python3.10/site-packages/setuptools/dist.py:530: UserWarning: Normalizing '2022.08.3' to '2022.8.3'
  warnings.warn(tmpl.format(**locals()))
running install
/usr/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
  warnings.warn(
running install_lib
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/test_sensor.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/const.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/__init__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/test_station.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/test_calc.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/tests/test_server.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests
creating /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/__main__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/calc.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/__init__.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/sensor.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/station.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
copying /var/tmp/portage/dev-python/aioecowitt-2022.8.3/work/aioecowitt-2022.8.3-python3_10/lib/aioecowitt/server.py -> /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/test_sensor.py to test_sensor.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/const.py to const.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/__init__.py to __init__.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/test_station.py to test_station.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/test_calc.py to test_calc.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/tests/test_server.py to test_server.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/__main__.py to __main__.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/calc.py to calc.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/__init__.py to __init__.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/sensor.py to sensor.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/station.py to station.cpython-310.pyc
byte-compiling /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt/server.py to server.cpython-310.pyc
writing byte-compilation script '/var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp97ngnuhf.py'
/usr/bin/python3.10 -Wignore:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning /var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp97ngnuhf.py
removing /var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp97ngnuhf.py
writing byte-compilation script '/var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp437zj8xn.py'
/usr/bin/python3.10 -Wignore:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning /var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp437zj8xn.py
removing /var/tmp/portage/dev-python/aioecowitt-2022.8.3/temp/tmp437zj8xn.py
running install_egg_info
running egg_info
writing aioecowitt.egg-info/PKG-INFO
writing dependency_links to aioecowitt.egg-info/dependency_links.txt
writing entry points to aioecowitt.egg-info/entry_points.txt
writing requirements to aioecowitt.egg-info/requires.txt
writing top-level names to aioecowitt.egg-info/top_level.txt
listing git files failed - pretending there aren't any
reading manifest file 'aioecowitt.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'aioecowitt.egg-info/SOURCES.txt'
Copying aioecowitt.egg-info to /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python3.10/site-packages/aioecowitt-2022.8.3-py3.10.egg-info
running install_scripts
Installing ecowitt-testserver script to /var/tmp/portage/dev-python/aioecowitt-2022.8.3/image/_python3.10/usr/lib/python-exec/python3.10
 * ERROR: dev-python/aioecowitt-2022.8.3::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 3330:  Called distutils-r1_src_install
 *   environment, line 1574:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  678:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3014:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2577:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2575:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1014:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1537:  Called _distutils-r1_post_python_install
 *   environment, line  578:  Called die
 * The specific snippet of code:
 *                   die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
```