### PR TITLE
Fix update_cb typing

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -21,7 +21,7 @@ class EcoWittSensor:
     value: None | str | int | float | dt.datetime = field(default=None, init=False)
     last_update: float = field(default=0, init=False)
     last_update_m: float = field(default=0, init=False)
-    update_cb: list[Callable[[None], None]] = field(default_factory=list, init=False)
+    update_cb: list[Callable[[], None]] = field(default_factory=list, init=False)
 
     def update_value(
         self,


### PR DESCRIPTION
The `update_cb` is only called without arguments.

https://github.com/home-assistant-libs/aioecowitt/blob/075fad4bc48b9a5c02d1dd6b40a7c34848bcd404/aioecowitt/sensor.py#L41-L43