### PR TITLE
Add support for raw soil moisture values

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -75,6 +75,7 @@ class EcoWittSensorTypes(enum.Enum):
     CO2_PPM = 27
     LUX = 28
     PERCENTAGE = 29
+    SOIL_RAWADC = 30
 
 
 @dataclass
@@ -214,6 +215,14 @@ SENSOR_MAP: dict[str, EcoWittMapping] = {
     "soilmoisture6": EcoWittMapping("Soil Moisture 6", EcoWittSensorTypes.HUMIDITY),
     "soilmoisture7": EcoWittMapping("Soil Moisture 7", EcoWittSensorTypes.HUMIDITY),
     "soilmoisture8": EcoWittMapping("Soil Moisture 8", EcoWittSensorTypes.HUMIDITY),
+    "soilad1": EcoWittMapping("Soil AD 1", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad2": EcoWittMapping("Soil AD 2", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad3": EcoWittMapping("Soil AD 3", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad4": EcoWittMapping("Soil AD 4", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad5": EcoWittMapping("Soil AD 5", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad6": EcoWittMapping("Soil AD 6", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad7": EcoWittMapping("Soil AD 7", EcoWittSensorTypes.SOIL_RAWADC),
+    "soilad8": EcoWittMapping("Soil AD 8", EcoWittSensorTypes.SOIL_RAWADC),
     "pm25_ch1": EcoWittMapping("PM2.5 1", EcoWittSensorTypes.PM25),
     "pm25_ch2": EcoWittMapping("PM2.5 2", EcoWittSensorTypes.PM25),
     "pm25_ch3": EcoWittMapping("PM2.5 3", EcoWittSensorTypes.PM25),

--- a/misc/fake_client.py
+++ b/misc/fake_client.py
@@ -63,6 +63,7 @@ paramset_b = {
     'solarradiation': 0.00,
     'uv': 0,
     'soilmoisture1': 0,
+    'soilad1': 120,
     'wh65batt': 1,
     'wh25batt': 0,
     'soilbatt1': 1.5,

--- a/tests/const.py
+++ b/tests/const.py
@@ -51,6 +51,7 @@ GW2000A_DATA = {
     "yrain_piezo": "0.000",
     "leak_ch1": "0",
     "leakbatt1": "5",
+    "soilad1": "120",
     "leafwetness_ch1": "14",
     "leaf_batt1": "1.78",
     "ws90cap_volt": "5.4",

--- a/tests/test_calc.py
+++ b/tests/test_calc.py
@@ -61,6 +61,7 @@ def test_gw2000a_v2():
         "leafwetness_ch1": 14,
         "leak_ch1": 0,
         "leakbatt1": 100,
+        "soilad1": "120",
         "ws90_ver": "119",
         "ws90cap_volt": 5.4,
         "yrain_piezo": 0.0,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,8 +41,8 @@ async def test_server_start(ecowitt_server, ecowitt_http) -> None:
     text = await resp.text()
     assert text == "OK"
 
-    assert len(sensors) == 50
-    assert len(ecowitt_server.sensors) == 50
+    assert len(sensors) == 51
+    assert len(ecowitt_server.sensors) == 51
     assert len(ecowitt_server.stations) == 1
 
     assert "PASSKEY" not in ecowitt_server.last_values[GW2000A_DATA["PASSKEY"]]
@@ -69,8 +69,8 @@ async def test_server_token(ecowitt_server, ecowitt_http) -> None:
     text = await resp.text()
     assert text == "OK"
 
-    assert len(sensors) == 50
-    assert len(ecowitt_server.sensors) == 50
+    assert len(sensors) == 51
+    assert len(ecowitt_server.sensors) == 51
     assert len(ecowitt_server.stations) == 1
 
 
@@ -95,6 +95,6 @@ async def test_server_multi_stations(ecowitt_server, ecowitt_http) -> None:
     text = await resp.text()
     assert text == "OK"
 
-    assert len(sensors) == 89
-    assert len(ecowitt_server.sensors) == 89
+    assert len(sensors) == 90
+    assert len(ecowitt_server.sensors) == 90
     assert len(ecowitt_server.stations) == 2


### PR DESCRIPTION
This is an alternative to https://github.com/home-assistant-libs/aioecowitt/pull/127 

That PR ignores soil moisture raw values, but what if someone wants access to the values? Why discard them? This instead adds support for them. This would help resolve Home-Assistant issue https://github.com/home-assistant/core/issues/102738

I spoke with Ecowitt directly and the soilad values are a raw analog to digital conversion. This value gets converted to the percentage using the formula `Soil_Moisture = (Now_AD - 0%AD) * 100% / (100% AD - 0%AD )` so if someone wants the raw value, this will now be exposed.