### PR TITLE
Add support for Ambient Weather variant

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -259,6 +259,7 @@ SENSOR_MAP: dict[str, EcoWittMapping] = {
     "co2": EcoWittMapping("WH45 CO2", EcoWittSensorTypes.CO2_PPM),
     "co2_24h": EcoWittMapping("WH45 CO2 24h average", EcoWittSensorTypes.CO2_PPM),
     "co2_batt": EcoWittMapping("WH45 Battery", EcoWittSensorTypes.BATTERY_PERCENTAGE),
+    "batt_co2": EcoWittMapping("WH45 Battery", EcoWittSensorTypes.BATTERY_PERCENTAGE),
     "leak_ch1": EcoWittMapping("Leak Detection 1", EcoWittSensorTypes.LEAK),
     "leak_ch2": EcoWittMapping("Leak Detection 2", EcoWittSensorTypes.LEAK),
     "leak_ch3": EcoWittMapping("Leak Detection 3", EcoWittSensorTypes.LEAK),

--- a/aioecowitt/server.py
+++ b/aioecowitt/server.py
@@ -92,11 +92,15 @@ class EcoWittListener:
 
     async def handler(self, request: web.BaseRequest) -> web.Response:
         """AIOHTTP handler for the API."""
-        if request.method != "POST":
-            return web.Response(status=405)
-        if self.path is not None and request.path != self.path:
-            return web.Response(status=404)
-        data = await request.post()
+        if request.method == "GET":
+            # Ambient Weather variant
+            data = request.query
+        else:
+            if request.method != "POST":
+                return web.Response(status=405)
+            if self.path is not None and request.path != self.path:
+                return web.Response(status=404)
+            data = await request.post()
 
         # data is not a dict, it's a MultiDict
         self.last_values[data["PASSKEY"]] = data.copy()

--- a/aioecowitt/station.py
+++ b/aioecowitt/station.py
@@ -25,7 +25,7 @@ def extract_station(data: dict[str, str]) -> EcoWittStation:
     """Extract station from data."""
     station = data.pop("stationtype")
     passkey = data.pop("PASSKEY")
-    model = data.pop("model")
+    model = data.pop("model", None)
     frequence = data.pop("freq", None)
 
     version = None


### PR DESCRIPTION
AmbientWeather and Ecowitt use nearly identical protocols.  Ecowitt uses a POST form, whereas AmbientWeather sends all data as params with a GET request.

The only other differences I found with my  WS2902 was it sends 'batt_co2'  instead of 'co2_batt' (even though it doesn't have any co2 sensor)

This plus a small home-asistant patch enabling 'GET' in the webhook were the only changes I needed to get my weather station working with HASS.