### PR TITLE
Add license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Topic :: Home Automation",
+        "License :: OSI Approved :: Apache Software License",
     ],
 )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing in the Home Assistant project and I was noticing we could not fetch the license from this repository because the license was not set in setup.py. Could you do a release after this and maybe bump it in Home Assistant?

Thanks