### PR TITLE
Update sensor.py - add WH46's PM1 and PM4 measurement support

### DIFF
--- a/aioecowitt/sensor.py
+++ b/aioecowitt/sensor.py
@@ -77,7 +77,9 @@ class EcoWittSensorTypes(enum.Enum):
     LUX = 28
     PERCENTAGE = 29
     SOIL_RAWADC = 30
-
+    PM1 = 31
+    PM4 = 32    
+    
 
 @dataclass
 class EcoWittMapping:
@@ -248,6 +250,10 @@ SENSOR_MAP: dict[str, EcoWittMapping] = {
     "tf_co2": EcoWittMapping("WH45 Temperature", EcoWittSensorTypes.TEMPERATURE_F),
     "tf_co2c": EcoWittMapping("WH45 Temperature", EcoWittSensorTypes.TEMPERATURE_C),
     "humi_co2": EcoWittMapping("WH45 Humidity", EcoWittSensorTypes.HUMIDITY),
+    "pm1_co2": EcoWittMapping("WH46 PM1 CO2", EcoWittSensorTypes.PM1),
+    "pm1_24h_co2": EcoWittMapping("WH46 PM1 CO2 24h average", EcoWittSensorTypes.PM1),
+    "pm4_co2": EcoWittMapping("WH46 PM4 CO2", EcoWittSensorTypes.PM4),
+    "pm4_24h_co2": EcoWittMapping("WH46 PM4 CO2 24h average", EcoWittSensorTypes.PM4),    
     "pm25_co2": EcoWittMapping("WH45 PM2.5 CO2", EcoWittSensorTypes.PM25),
     "pm25_24h_co2": EcoWittMapping(
         "WH45 PM2.5 CO2 24h average", EcoWittSensorTypes.PM25


### PR DESCRIPTION
Add support of WH46 air quality sensor's PM1 + PM4 measurement to fix https://github.com/home-assistant/core/issues/125003

Code changes are required on both home-assistant-libs/aioecowitt/aioecowitt/sensor.py and home-assistant/core/homeassistant/components/ecowitt/sensor.py, so this is only the first PR of two. Due to the library dependency, approval of this PR will be required before the other can be issued. 

Both code changes are already tested successfully on my install. 

