### PR TITLE
Fix pytest-asyncio deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,9 @@ dependencies = [
 [project.scripts]
 ecowitt-testserver = "aioecowitt.__main__:main"
 
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "auto"
+
 [tool.setuptools.packages.find]
 include = ["aioecowitt*"]

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,5 +1,6 @@
 pytest==8.3.5
 pytest-aiohttp==1.1.0
+pytest-asyncio==1.1.0
 pytest-timeout==2.4.0
 black==25.1.0
 flake8==7.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,7 @@ def ecowitt_server():
 
 
 @pytest.fixture
-def ecowitt_http(event_loop, aiohttp_raw_server, aiohttp_client, ecowitt_server):
+async def ecowitt_http(aiohttp_raw_server, aiohttp_client, ecowitt_server):
     """EcoWitt HTTP fixture."""
-    raw_server = event_loop.run_until_complete(
-        aiohttp_raw_server(ecowitt_server.handler)
-    )
-    return event_loop.run_until_complete(aiohttp_client(raw_server))
+    raw_server = await aiohttp_raw_server(ecowitt_server.handler)
+    return await aiohttp_client(raw_server)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,17 +1,13 @@
 """Test ecowitt sensor module."""
 
-import pytest
-
-from aioecowitt import server
-
 from .const import GW2000A_V3_DATA
-from aioecowitt import sensor
+from aioecowitt.sensor import EcoWittSensor, EcoWittSensorTypes
 
 
 def test_update_listener() -> None:
     """Test on change get updates from callback."""
-    ecowit_sensor = sensor.EcoWittSensor(
-        "test", "test", sensor.EcoWittSensorTypes.TEMPERATURE_C, "test"
+    ecowit_sensor = EcoWittSensor(
+        "test", "test", EcoWittSensorTypes.TEMPERATURE_C, "test"
     )
 
     called = False
@@ -34,12 +30,11 @@ def test_update_listener() -> None:
     assert called
 
 
-@pytest.mark.asyncio
 async def test_heap_field(ecowitt_server, ecowitt_http) -> None:
     """Test handling of heap field."""
     heap_sensor = None
 
-    def on_change(sensor: server.EcoWittSensor) -> None:
+    def on_change(sensor: EcoWittSensor) -> None:
         """Test callback."""
         if sensor.key == "heap":
             nonlocal heap_sensor

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,5 @@
 """EcoWitt server tests."""
 
-import pytest
-
 from aioecowitt import server
 
 from .const import GW2000A_DATA, EASYWEATHER_DATA
@@ -9,7 +7,6 @@ from .const import GW2000A_DATA, EASYWEATHER_DATA
 # pylint: disable=redefined-outer-name
 
 
-@pytest.mark.asyncio
 async def test_server_start(ecowitt_server, ecowitt_http) -> None:
     """Test server start."""
     sensors = []
@@ -32,7 +29,6 @@ async def test_server_start(ecowitt_server, ecowitt_http) -> None:
     assert "PASSKEY" not in ecowitt_server.last_values[GW2000A_DATA["PASSKEY"]]
 
 
-@pytest.mark.asyncio
 async def test_server_token(ecowitt_server, ecowitt_http) -> None:
     """Test server start."""
     sensors = []
@@ -58,7 +54,6 @@ async def test_server_token(ecowitt_server, ecowitt_http) -> None:
     assert len(ecowitt_server.stations) == 1
 
 
-@pytest.mark.asyncio
 async def test_server_multi_stations(ecowitt_server, ecowitt_http) -> None:
     """Test server start and multiple stations."""
     sensors = []


### PR DESCRIPTION
- Pin pytest-asyncio, used by pytest-aiohttp, since pytest-aiohttp doesn't pin it, and deprecations in pytest-asyncio directly impact our tests.
- Solve deprecations.
- Some small import clean ups.